### PR TITLE
Revert "Update docker.io/bitnami/postgresql Docker tag to v16"

### DIFF
--- a/manifests/keycloak/keycloak.yaml
+++ b/manifests/keycloak/keycloak.yaml
@@ -197,7 +197,7 @@ spec:
       hostIPC: false
       containers:
         - name: postgresql
-          image: docker.io/bitnami/postgresql:16.1.0-debian-11-r26
+          image: docker.io/bitnami/postgresql:15.2.0-debian-11-r26
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsUser: 1001


### PR DESCRIPTION
Reverts YeloMelo95/104-400MVB#146
Not compatible with existing DB used by Keycloak